### PR TITLE
Trackcountlog

### DIFF
--- a/Data_lake_process/trackcountlog_error.py
+++ b/Data_lake_process/trackcountlog_error.py
@@ -98,12 +98,19 @@ def query_datasource():
     return df_
 
 
-def update_sheet(df, gsheet_url):
+def update_sheet(df, gsheet_url, sheet_index):
     sh = gc.open_by_url(gsheet_url)
-    worksheet = sh.get_worksheet(0)
-    worksheet.clear()
-    set_with_dataframe(worksheet, df)
-    format_with_dataframe(worksheet, df, include_column_header=True)
+    worksheet = sh.get_worksheet(sheet_index)
+    if sheet_index == 0:
+        worksheet.clear()
+        set_with_dataframe(worksheet, df)
+        format_with_dataframe(worksheet, df, include_column_header=True)
+        return True
+    else:
+        worksheet.add_rows(df.shape[0])
+        set_with_dataframe(worksheet, df, include_column_header=False, row=worksheet.row_count+1)
+        return True
+
 
 
 def send_slack(df, gsheet_url):
@@ -141,14 +148,15 @@ if __name__ == "__main__":
     gsheet_url = "https://docs.google.com/spreadsheets/d/1yJS1JjkaoNy2akdEbpTeQnKJgjji-1h9BHnFbyQ6XQc/edit#gid=133198295"
     df = query_datasource()
     print(df.head())
-    update_sheet(df, gsheet_url)
+    update_sheet(df=df, gsheet_url=gsheet_url,sheet_index=0)
     if len(df) > 0:
+        update_sheet(df=df, gsheet_url=gsheet_url,sheet_index=1)
         change_valid_negative(df)
         time.sleep(1500)
         change_valid_positive(df)
         time.sleep(1500)
         dff = query_datasource()
-        update_sheet(dff, gsheet_url)
+        update_sheet(dff, gsheet_url, 0)
         send_slack(dff, gsheet_url)
     else:
         send_slack(df, gsheet_url)

--- a/Data_lake_process/trackcountlog_error.py
+++ b/Data_lake_process/trackcountlog_error.py
@@ -11,7 +11,7 @@ from core.models.trackcountlog import TrackCountLog
 from core.models.track import Track
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker, aliased
-from sqlalchemy import func, union, distinct, desc, and_, or_, tuple_, extract
+from sqlalchemy import func, union, distinct, desc, and_, or_, tuple_, extract, update
 from core.mysql_database_connection.sqlalchemy_create_engine import (
     SQLALCHEMY_DATABASE_URI,
 )
@@ -55,7 +55,7 @@ def query_datasource():
             Track.valid == 1,
             DataSource.valid == 1,
             DataSource.created_at > TrackCountLog.updated_at,
-            DataSource.format_id.in_(formatid_list)
+            DataSource.format_id.in_(formatid_list),
         )
     )
     subquery1 = (
@@ -84,38 +84,75 @@ def query_datasource():
             DataSource.track_id.in_(subquery1),
             DataSource.track_id.notin_(subquery2),
             DataSource.valid == 1,
-            DataSource.format_id.in_(formatid_list)
+            DataSource.format_id.in_(formatid_list),
         )
-        )
+    )
     query3 = query1.union(query2)
     df_ = get_df_from_query(query3)
-    # date = datetime.now().date()
-    gsheet_url = "https://docs.google.com/spreadsheets/d/1yJS1JjkaoNy2akdEbpTeQnKJgjji-1h9BHnFbyQ6XQc/edit#gid=133198295"
+    if len(df_) > 0:
+        df_ = df_[df_["format_id"].isin(formatid_list)].sort_values(
+            ["trackcountlog_updatedat", "datasource_updatedat", "datasource_createdat"],
+            ascending=False,
+        )
+        df_["script_date"] = datetime.now().date()
+    return df_
+
+
+def update_sheet(df, gsheet_url):
     sh = gc.open_by_url(gsheet_url)
-    print(df_.columns)
-    df_ = df_[df_["format_id"].isin(formatid_list)].sort_values(
-        ["trackcountlog_updatedat", "datasource_updatedat", "datasource_createdat"],
-        ascending=False
-    )
-    df_["script_date"] = datetime.now().date()
     worksheet = sh.get_worksheet(0)
-    dff = get_as_dataframe(worksheet)
-    df = pd.concat([df_, dff])
+    worksheet.clear()
     set_with_dataframe(worksheet, df)
     format_with_dataframe(worksheet, df, include_column_header=True)
+
+
+def send_slack(df, gsheet_url):
     slack = trackcountlog_error_message(
-        trackcountlog_error, datetime.now().date(), gsheet_url, len(df_)
+        trackcountlog_error, datetime.now().date(), gsheet_url, len(df)
     )
-    if len(df_) > 0:
+    if len(df) > 0:
         slack.send_slack_error()
     else:
         slack.send_slack_report()
 
 
+def change_valid_negative(df):
+    datasource_ids = df["datasource_id"].values.tolist()
+    update = (
+        db_session.query(DataSource)
+        .filter(DataSource.id.in_(datasource_ids))
+        .update({"valid": -96}, synchronize_session="fetch")
+    )
+    db_session.commit()
+
+
+def change_valid_positive(df):
+    datasource_ids = df["datasource_id"].values.tolist()
+    update = (
+        db_session.query(DataSource)
+        .filter(DataSource.id.in_(datasource_ids))
+        .update({"valid": 1}, synchronize_session="fetch")
+    )
+    db_session.commit()
 
 
 if __name__ == "__main__":
     start = time.time()
-    query_datasource()
-    print("\n --- total time to process %s seconds ---" % (time.time() - start))
-
+    gsheet_url = "https://docs.google.com/spreadsheets/d/1yJS1JjkaoNy2akdEbpTeQnKJgjji-1h9BHnFbyQ6XQc/edit#gid=133198295"
+    df = query_datasource()
+    print(df.head())
+    update_sheet(df, gsheet_url)
+    if len(df) > 0:
+        change_valid_negative(df)
+        time.sleep(1500)
+        change_valid_positive(df)
+        time.sleep(1500)
+        dff = query_datasource()
+        update_sheet(dff, gsheet_url)
+        send_slack(dff, gsheet_url)
+    # else:
+    # send_slack(df, gsheet_url)
+    print(
+        "\n --- total time to process minus sleeping time %s seconds ---"
+        % (time.time() - start)
+    )

--- a/Data_lake_process/trackcountlog_error.py
+++ b/Data_lake_process/trackcountlog_error.py
@@ -150,9 +150,9 @@ if __name__ == "__main__":
         dff = query_datasource()
         update_sheet(dff, gsheet_url)
         send_slack(dff, gsheet_url)
-    # else:
-    # send_slack(df, gsheet_url)
+    else:
+        send_slack(df, gsheet_url)
     print(
-        "\n --- total time to process minus sleeping time %s seconds ---"
+        "\n --- total time to process %s seconds ---"
         % (time.time() - start)
     )


### PR DESCRIPTION
separate different steps into smaller functions
if query returns a non-empty dataframe, change `datasource.valid` to -96 then back to 1 to kickstart chaging `trackcountlog.updated_at`, then query again to make sure that all datasource IDs have been updated properly